### PR TITLE
Add recursive shop-type category filter

### DIFF
--- a/docs/backend-schema.md
+++ b/docs/backend-schema.md
@@ -1,0 +1,24 @@
+# Suggested Backend Schema
+
+To store hierarchical Shop-Type categories with attributes, a SQL schema using a self-referencing table works well. Each category references its parent, allowing unlimited levels of nesting.
+
+```sql
+CREATE TABLE shop_type (
+    id SERIAL PRIMARY KEY,
+    parent_id INTEGER REFERENCES shop_type(id),
+    name TEXT NOT NULL,
+    price_range TEXT,
+    opening_hours TEXT,
+    delivery_available BOOLEAN,
+    pet_friendly BOOLEAN,
+    wifi BOOLEAN,
+    parking BOOLEAN,
+    accepts_credit_cards BOOLEAN,
+    reservation_required BOOLEAN,
+    halal_friendly BOOLEAN,
+    vegan_friendly BOOLEAN,
+    covid_safe BOOLEAN
+);
+```
+
+For NoSQL (e.g. MongoDB), each document could include an array of child categories to store the tree in a single document.

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import ShopTypeFilter from './ShopTypeFilter';
 
 const FilterBar = ({ onFilterChange, language }) => {
   const [selectedFilters, setSelectedFilters] = useState({
@@ -60,6 +61,12 @@ const FilterBar = ({ onFilterChange, language }) => {
     onFilterChange(updatedFilters);
   };
 
+  const handleShopTypeSelect = (value) => {
+    const updated = { ...selectedFilters, shopType: value };
+    setSelectedFilters(updated);
+    onFilterChange(updated);
+  };
+
   return (
     <div className="filter-bar">
       <div className="filter-row">
@@ -95,6 +102,11 @@ const FilterBar = ({ onFilterChange, language }) => {
           ))}
         </div>
       )}
+
+      <ShopTypeFilter
+        selected={selectedFilters.shopType}
+        onSelect={handleShopTypeSelect}
+      />
 
       {Object.entries(locationLevels).map(([level, options]) => {
         const prevLevel = Object.keys(locationLevels)[Object.keys(locationLevels).indexOf(level) - 1];

--- a/src/components/ShopTypeFilter.jsx
+++ b/src/components/ShopTypeFilter.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { shopTypes } from '../data/shopTypes';
+import '../styles/ShopTypeFilter.css';
+
+const ShopTypeItem = ({ node, depth, onSelect, selected }) => {
+  const hasChildren = node.children && node.children.length > 0;
+  const isActive = selected === node.id;
+  return (
+    <div className="shop-type-item" style={{ marginLeft: depth * 12 }}>
+      <button
+        className={`shop-type-button ${isActive ? 'shoptype-active' : ''}`}
+        onClick={() => onSelect(node.id)}
+      >
+        {node.name}
+      </button>
+      {hasChildren && (
+        <div className="shop-type-children">
+          {node.children.map(child => (
+            <ShopTypeItem
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              onSelect={onSelect}
+              selected={selected}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ShopTypeFilter = ({ selected, onSelect }) => (
+  <div className="shop-type-section">
+    {shopTypes.map(root => (
+      <ShopTypeItem
+        key={root.id}
+        node={root}
+        depth={0}
+        onSelect={onSelect}
+        selected={selected}
+      />
+    ))}
+  </div>
+);
+
+export default ShopTypeFilter;

--- a/src/data/shopTypeInterfaces.ts
+++ b/src/data/shopTypeInterfaces.ts
@@ -1,0 +1,20 @@
+export interface ShopAttributes {
+  priceRange?: string;
+  openingHours?: string;
+  deliveryAvailable?: boolean;
+  petFriendly?: boolean;
+  wifi?: boolean;
+  parking?: boolean;
+  acceptsCreditCards?: boolean;
+  reservationRequired?: boolean;
+  halalFriendly?: boolean;
+  veganFriendly?: boolean;
+  covidSafe?: boolean;
+}
+
+export interface ShopType {
+  id: string;
+  name: string;
+  attributes?: ShopAttributes;
+  children?: ShopType[];
+}

--- a/src/data/shopTypes.js
+++ b/src/data/shopTypes.js
@@ -1,0 +1,48 @@
+export const shopTypes = [
+  {
+    id: 'food-beverage',
+    name: 'Food & Beverage',
+    children: [
+      {
+        id: 'restaurants',
+        name: 'Restaurants',
+        children: [
+          { id: 'thai', name: 'Thai' },
+          { id: 'japanese', name: 'Japanese' },
+          { id: 'italian', name: 'Italian' }
+        ]
+      },
+      {
+        id: 'cafes-desserts',
+        name: 'Cafés & Desserts',
+        children: [
+          { id: 'coffee-shops', name: 'Coffee Shops' },
+          { id: 'bakeries', name: 'Bakeries' }
+        ]
+      },
+      {
+        id: 'street-food',
+        name: 'Street Food & Stalls',
+        children: [
+          { id: 'noodle-stalls', name: 'Noodle Stalls' },
+          { id: 'skewers', name: 'Skewers' }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'retail-shopping',
+    name: 'Retail & Shopping',
+    children: [
+      {
+        id: 'fashion-accessories',
+        name: 'Fashion & Accessories',
+        children: [
+          { id: 'clothing', name: 'Clothing' },
+          { id: 'shoes', name: 'Shoes' },
+          { id: 'bags', name: 'Bags' }
+        ]
+      }
+    ]
+  }
+];

--- a/src/styles/ShopTypeFilter.css
+++ b/src/styles/ShopTypeFilter.css
@@ -1,0 +1,34 @@
+.shop-type-section {
+  margin: 8px 0;
+  padding: 8px 0;
+  border-top: 1px solid #2f313d;
+}
+
+.shop-type-button {
+  padding: 6px 12px;
+  background: #2a2d3d;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s ease;
+  opacity: 0.8;
+}
+
+.shop-type-button:hover {
+  opacity: 1;
+  background: #3a3d4d;
+}
+
+.shop-type-button.shoptype-active {
+  background: #e67e22;
+  opacity: 1;
+}
+
+.shop-type-children {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}


### PR DESCRIPTION
## Summary
- add TypeScript interfaces describing shop type categories and attributes
- provide example hierarchical shop type data
- implement `ShopTypeFilter` component for recursive rendering
- integrate new filter into `FilterBar`
- style shop type filters with unique color
- document suggested backend schema for storing shop types

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d636bb9c83298076d0f1763441b7