### PR TITLE
Add multi-layer toggle demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,17 @@ function App() {
 ```
 
 Styles are defined in `src/styles/CategoryTabs.css`.
+
+## Multi-Layer Toggle Demo
+
+`MultiLayerToggle` renders a tree of buttons for shop types or locations. Each depth has its own shade and each type uses a separate color palette.
+
+```jsx
+import MultiLayerToggleDemo from './components/MultiLayerToggleDemo';
+
+function App() {
+  return <MultiLayerToggleDemo />;
+}
+```
+
+Demo categories are defined in `src/data/multiLayerCategories.js`. Styles live in `src/styles/MultiLayerToggle.css`.

--- a/src/components/MultiLayerToggle.jsx
+++ b/src/components/MultiLayerToggle.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import '../styles/MultiLayerToggle.css';
+
+/**
+ * Recursive toggle tree for categories or locations.
+ * Props:
+ * - data: array of category nodes { id, label, children? }
+ * - type: "shop" | "location" (controls color palette)
+ * - selectedId: currently selected node id
+ * - onSelect: callback when a leaf or node is clicked
+ */
+const colorPalettes = {
+  shop: ['#0d47a1', '#1976d2', '#64b5f6'],
+  location: ['#2e7d32', '#66bb6a', '#a5d6a7']
+};
+
+const ToggleItem = ({ node, depth, type, selectedId, onSelect }) => {
+  const colors = colorPalettes[type] || [];
+  const color = colors[Math.min(depth, colors.length - 1)] || '#555';
+  const isSelected = selectedId === node.id;
+
+  return (
+    <div className="toggle-item">
+      <button
+        className={`toggle-chip ${isSelected ? 'selected' : ''}`}
+        style={{ '--chip-color': color }}
+        onClick={() => onSelect(node.id)}
+      >
+        {node.label}
+      </button>
+      {node.children && (
+        <div className="toggle-children">
+          {node.children.map(child => (
+            <ToggleItem
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              type={type}
+              selectedId={selectedId}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const MultiLayerToggle = ({ data, type, selectedId, onSelect }) => (
+  <div className="multi-layer-toggle">
+    {data.map(node => (
+      <ToggleItem
+        key={node.id}
+        node={node}
+        depth={0}
+        type={type}
+        selectedId={selectedId}
+        onSelect={onSelect}
+      />
+    ))}
+  </div>
+);
+
+export default MultiLayerToggle;

--- a/src/components/MultiLayerToggleDemo.jsx
+++ b/src/components/MultiLayerToggleDemo.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import MultiLayerToggle from './MultiLayerToggle';
+import { multiLayerCategories } from '../data/multiLayerCategories';
+
+/**
+ * Example component showing how to use MultiLayerToggle
+ * for both shop type and location categories.
+ */
+const MultiLayerToggleDemo = () => {
+  const [selected, setSelected] = useState('');
+
+  return (
+    <div style={{ padding: '16px' }}>
+      <h3>Shop Type</h3>
+      <MultiLayerToggle
+        data={multiLayerCategories.shop}
+        type="shop"
+        selectedId={selected}
+        onSelect={setSelected}
+      />
+
+      <h3 style={{ marginTop: '24px' }}>Location</h3>
+      <MultiLayerToggle
+        data={multiLayerCategories.location}
+        type="location"
+        selectedId={selected}
+        onSelect={setSelected}
+      />
+
+      <p style={{ marginTop: '16px' }}>Selected: {selected || 'none'}</p>
+    </div>
+  );
+};
+
+export default MultiLayerToggleDemo;

--- a/src/data/multiLayerCategories.js
+++ b/src/data/multiLayerCategories.js
@@ -1,0 +1,69 @@
+export const multiLayerCategories = {
+  shop: [
+    {
+      id: 'food',
+      label: 'Food',
+      children: [
+        {
+          id: 'restaurant',
+          label: 'Restaurant',
+          children: [
+            { id: 'italian', label: 'Italian' },
+            { id: 'thai', label: 'Thai' }
+          ]
+        },
+        {
+          id: 'cafe',
+          label: 'Cafe',
+          children: [
+            { id: 'coffee', label: 'Coffee Shop' }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'retail',
+      label: 'Retail',
+      children: [
+        {
+          id: 'clothing',
+          label: 'Clothing',
+          children: [
+            { id: 'mens', label: 'Mens' },
+            { id: 'womens', label: 'Womens' }
+          ]
+        }
+      ]
+    }
+  ],
+  location: [
+    {
+      id: 'bangkok',
+      label: 'Bangkok',
+      children: [
+        {
+          id: 'sukhumvit',
+          label: 'Sukhumvit',
+          children: [
+            { id: 'soi1', label: 'Soi 1' },
+            { id: 'soi2', label: 'Soi 2' }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'chiangmai',
+      label: 'Chiang Mai',
+      children: [
+        {
+          id: 'nimman',
+          label: 'Nimman',
+          children: [
+            { id: 'lane1', label: 'Lane 1' },
+            { id: 'lane2', label: 'Lane 2' }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/src/styles/MultiLayerToggle.css
+++ b/src/styles/MultiLayerToggle.css
@@ -1,0 +1,37 @@
+.multi-layer-toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.toggle-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.toggle-children {
+  display: flex;
+  flex-direction: column;
+  margin-left: 16px;
+  gap: 6px;
+}
+
+.toggle-chip {
+  padding: 6px 12px;
+  border: 1px solid var(--chip-color);
+  border-radius: 16px;
+  background: transparent;
+  color: var(--chip-color);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.toggle-chip:hover {
+  background: var(--chip-color);
+  color: #fff;
+}
+
+.toggle-chip.selected {
+  background: var(--chip-color);
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add reusable `MultiLayerToggle` component for shop type vs location palettes
- demo with `MultiLayerToggleDemo`
- include sample data with three nesting levels
- document usage in `README`
- provide component styles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dd636aec832984e686d735af4f85