### PR TITLE
Add dropdown component

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,17 @@ function App() {
 Demo categories are defined in `src/data/multiLayerCategories.js`. Styles live in `src/styles/MultiLayerToggle.css`.
 
 The demo includes a language toggle showing English and Thai labels and a small search box to filter categories.
+## Simple Dropdown Component
+
+`Dropdown` displays a compact trigger button that expands into a large scrollable menu when clicked.
+
+```jsx
+import Dropdown from './components/Dropdown';
+
+function Example() {
+  const options = ['One', 'Two', 'Three', 'Four'];
+  return <Dropdown options={options} onSelect={(o) => console.log(o)} />;
+}
+```
+
+Styles live in `src/styles/Dropdown.css`.

--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useRef, useEffect } from 'react';
+import '../styles/Dropdown.css';
+
+/**
+ * A dropdown component with a compact trigger button but a large menu.
+ * Props:
+ * - options: array of option strings
+ * - onSelect(option): callback when an option is clicked
+ * - placeholder: button text when no option selected
+ */
+const Dropdown = ({ options = [], onSelect, placeholder = 'Select' }) => {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState(null);
+  const menuRef = useRef(null);
+  const wrapperRef = useRef(null);
+
+  const handleClickOutside = (e) => {
+    if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+      setOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleOptionClick = (option) => {
+    setSelected(option);
+    setOpen(false);
+    if (onSelect) onSelect(option);
+  };
+
+  return (
+    <div className="dropdown" ref={wrapperRef}>
+      <button
+        className="dropdown-trigger"
+        onClick={() => setOpen((prev) => !prev)}
+        type="button"
+      >
+        {selected || placeholder}
+      </button>
+      {open && (
+        <div className="dropdown-menu" ref={menuRef}>
+          {options.map((opt) => (
+            <button
+              key={opt}
+              className="dropdown-option"
+              onClick={() => handleOptionClick(opt)}
+              type="button"
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/styles/Dropdown.css
+++ b/src/styles/Dropdown.css
@@ -1,0 +1,46 @@
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdown-trigger {
+  width: 90px;
+  min-height: 32px;
+  padding: 4px 8px;
+  border: 1px solid #2a2d3d;
+  background: #2a2d3d;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  width: 300px;
+  max-height: 300px;
+  background: #1a1d2d;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  overflow-y: auto;
+  padding: 8px 0;
+  z-index: 1000;
+}
+
+.dropdown-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 16px;
+  border: none;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.dropdown-option:hover {
+  background: #2a2d3d;
+}


### PR DESCRIPTION
## Summary
- create a general purpose Dropdown component
- style the new dropdown with compact trigger and large menu
- document example usage in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f4be27048329a8d8f312e150403f