### PR TITLE
Improve dark styling and filter toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,33 @@ function App() {
 Demo categories are defined in `src/data/multiLayerCategories.js`. Styles live in `src/styles/MultiLayerToggle.css`.
 
 The demo includes a language toggle showing English and Thai labels and a small search box to filter categories.
+## Simple Dropdown Component
+
+`Dropdown` displays a compact trigger button that expands into a large scrollable menu when clicked.
+
+```jsx
+import Dropdown from './components/Dropdown';
+
+function Example() {
+  const options = ['One', 'Two', 'Three', 'Four'];
+  return <Dropdown options={options} onSelect={(o) => console.log(o)} />;
+}
+```
+
+Styles live in `src/styles/Dropdown.css`.
+
+## Compact Review Card
+
+`CompactReviewCard` presents a sleek summary of a review item using the Inter font and subtle shadows. The card uses a dark gray background to match the rest of the app. Only the first review quote is shown with an avatar and a verified badge.
+
+```jsx
+import CompactReviewCard from './components/CompactReviewCard';
+
+function ReviewExample({ item, onDetails }) {
+  return <CompactReviewCard item={item} onDetails={onDetails} />;
+}
+```
+
+Styles live in `src/styles/CompactReviewCard.css`.
+
+`ItemList` now renders each shop using `CompactReviewCard` for a smaller display.

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,12 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/components/CompactReviewCard.jsx
+++ b/src/components/CompactReviewCard.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { MessageCircle, CheckCircle, MapPin, ArrowRight } from 'lucide-react';
+import StarRating from './StarRating';
+import '../styles/CompactReviewCard.css';
+
+const CompactReviewCard = ({ item, onDetails }) => {
+  const review = item.reviews && item.reviews.length > 0 ? item.reviews[0] : null;
+  const avatarLetter = review ? review.author.charAt(0).toUpperCase() : '';
+
+  return (
+    <div className="compact-review-card">
+      <div className="crc-header">
+        <h3 className="crc-title">{item.itemName}</h3>
+        <div className="crc-rating">
+          <StarRating rating={item.rating} size="sm" />
+          <span className="crc-rating-val">{item.rating ? item.rating.toFixed(1) : 'N/A'}</span>
+          <MessageCircle size={12} className="crc-icon" />
+          <span className="crc-review-count">{item.reviewCount || 0}</span>
+        </div>
+      </div>
+      <div className="crc-tags">
+        {item.category && (
+          <span className="crc-badge">
+            <MapPin size={10} className="crc-badge-icon" />
+            {item.category}
+          </span>
+        )}
+        {item.location && item.location.city && (
+          <span className="crc-badge">{item.location.city}</span>
+        )}
+      </div>
+      {review && (
+        <div className="crc-quote">
+          <div className="crc-avatar">{avatarLetter}</div>
+          <div className="crc-quote-text">
+            <div className="crc-author-line">
+              <span className="crc-author">{review.author}</span>
+              {review.verified && <CheckCircle size={12} className="crc-verified" />}
+            </div>
+            <p className="crc-comment">"{review.comment}"</p>
+          </div>
+        </div>
+      )}
+      <button type="button" className="crc-details" onClick={() => onDetails && onDetails(item)}>
+        View details <ArrowRight size={14} />
+      </button>
+    </div>
+  );
+};
+
+export default CompactReviewCard;

--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useRef, useEffect } from 'react';
+import '../styles/Dropdown.css';
+
+/**
+ * A dropdown component with a compact trigger button but a large menu.
+ * Props:
+ * - options: array of option strings
+ * - onSelect(option): callback when an option is clicked
+ * - placeholder: button text when no option selected
+ */
+const Dropdown = ({ options = [], onSelect, placeholder = 'Select' }) => {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState(null);
+  const menuRef = useRef(null);
+  const wrapperRef = useRef(null);
+
+  const handleClickOutside = (e) => {
+    if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+      setOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleOptionClick = (option) => {
+    setSelected(option);
+    setOpen(false);
+    if (onSelect) onSelect(option);
+  };
+
+  return (
+    <div className="dropdown" ref={wrapperRef}>
+      <button
+        className="dropdown-trigger"
+        onClick={() => setOpen((prev) => !prev)}
+        type="button"
+      >
+        {selected || placeholder}
+      </button>
+      {open && (
+        <div className="dropdown-menu" ref={menuRef}>
+          {options.map((opt) => (
+            <button
+              key={opt}
+              className="dropdown-option"
+              onClick={() => handleOptionClick(opt)}
+              type="button"
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -78,20 +78,28 @@ const FilterBar = ({ onFilterChange, language }) => {
     const levels = Object.keys(locationLevels);
     const currentIndex = levels.indexOf(level);
 
-    levels.forEach((filterLevel, index) => {
-      if (index === currentIndex) {
-        updatedFilters[filterLevel] = value;
-      } else if (index > currentIndex) {
-        updatedFilters[filterLevel] = '';
-      }
-    });
+    if (updatedFilters[level] === value) {
+      // toggle off
+      levels.slice(currentIndex).forEach((l) => {
+        updatedFilters[l] = '';
+      });
+    } else {
+      levels.forEach((filterLevel, index) => {
+        if (index === currentIndex) {
+          updatedFilters[filterLevel] = value;
+        } else if (index > currentIndex) {
+          updatedFilters[filterLevel] = '';
+        }
+      });
+    }
 
     setSelectedFilters(updatedFilters);
     onFilterChange(updatedFilters);
   };
 
   const handleShopTypeSelect = (value) => {
-    const updated = { ...selectedFilters, shopType: value };
+    const newValue = selectedFilters.shopType === value ? '' : value;
+    const updated = { ...selectedFilters, shopType: newValue };
     setSelectedFilters(updated);
     onFilterChange(updated);
   };
@@ -104,7 +112,8 @@ const FilterBar = ({ onFilterChange, language }) => {
             key={cat.value}
             className={`filter-button ${selectedFilters.category === cat.value ? 'active' : ''}`}
             onClick={() => {
-              const updated = { ...selectedFilters, category: cat.value, onlineType: '' };
+              const newCategory = selectedFilters.category === cat.value ? '' : cat.value;
+              const updated = { ...selectedFilters, category: newCategory, onlineType: '' };
               setSelectedFilters(updated);
               onFilterChange(updated);
             }}
@@ -121,7 +130,8 @@ const FilterBar = ({ onFilterChange, language }) => {
               key={opt.value}
               className={`filter-button ${selectedFilters.onlineType === opt.value ? 'active' : ''}`}
               onClick={() => {
-                const updated = { ...selectedFilters, onlineType: opt.value };
+                const newVal = selectedFilters.onlineType === opt.value ? '' : opt.value;
+                const updated = { ...selectedFilters, onlineType: newVal };
                 setSelectedFilters(updated);
                 onFilterChange(updated);
               }}

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Sparkles } from 'lucide-react';
-import ReviewItem from './ReviewItem';
+import CompactReviewCard from './CompactReviewCard';
 
 const ItemList = ({
   filteredReviews,
@@ -17,7 +17,7 @@ const ItemList = ({
   generateImage,
 }) => (
   <main className="max-w-7xl mx-auto px-4 py-8">
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       {!isAuthReady ? (
         <div className="text-center py-20 col-span-full">
           <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-purple-600/20 to-blue-600/20 rounded-full mb-4">
@@ -27,17 +27,10 @@ const ItemList = ({
         </div>
       ) : filteredReviews.length > 0 ? (
         filteredReviews.map((item) => (
-          <ReviewItem
+          <CompactReviewCard
             key={item.id}
-            generateImage={generateImage}
             item={item}
-            onClick={handleItemClick}
-            language={language}
-            categories={categories}
-            citiesData={citiesData}
-            bangkokStreetsData={bangkokStreetsData}
-            generatedImages={generatedImages}
-            setGeneratedImages={setGeneratedImages}
+            onDetails={handleItemClick}
           />
         ))
       ) : (

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --card-bg: #23272f;
+}
+
 /* Global body styles for consistent layout */
 body {
   @apply m-0 bg-gray-950 text-gray-100 font-sans;
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
 }

--- a/src/styles/CompactReviewCard.css
+++ b/src/styles/CompactReviewCard.css
@@ -1,0 +1,61 @@
+.compact-review-card {
+  background-color: var(--card-bg, #23272f);
+  @apply text-gray-100 rounded-lg shadow border border-gray-700 p-3 flex flex-col justify-between hover:shadow-md transition-transform duration-200;
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+}
+
+.crc-header {
+  @apply flex items-center justify-between gap-2;
+}
+
+.crc-title {
+  @apply text-xs font-semibold truncate;
+}
+
+.crc-rating {
+  @apply flex items-center gap-1 text-xs text-gray-400;
+}
+
+.crc-rating-val {
+  @apply font-medium;
+}
+
+.crc-tags {
+  @apply mt-0.5 flex flex-wrap gap-1;
+}
+
+.crc-badge {
+  @apply flex items-center gap-1 bg-gray-700 text-gray-200 text-xs px-2 py-0.5 rounded-full;
+}
+
+.crc-badge-icon {
+  @apply text-gray-400;
+}
+
+.crc-quote {
+  @apply mt-1 flex gap-1 text-xs text-gray-300;
+}
+
+.crc-avatar {
+  @apply w-6 h-6 rounded-full bg-gray-600 text-gray-200 flex items-center justify-center text-xs font-semibold;
+}
+
+.crc-author-line {
+  @apply flex items-center gap-1;
+}
+
+.crc-author {
+  @apply font-semibold;
+}
+
+.crc-verified {
+  @apply text-blue-500;
+}
+
+.crc-comment {
+  @apply leading-snug;
+}
+
+.crc-details {
+  @apply mt-2 self-end text-xs text-blue-600 hover:underline inline-flex items-center gap-1;
+}

--- a/src/styles/Dropdown.css
+++ b/src/styles/Dropdown.css
@@ -1,0 +1,46 @@
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdown-trigger {
+  width: 90px;
+  min-height: 32px;
+  padding: 4px 8px;
+  border: 1px solid #2a2d3d;
+  background: #2a2d3d;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  width: 300px;
+  max-height: 300px;
+  background: #1a1d2d;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  overflow-y: auto;
+  padding: 8px 0;
+  z-index: 1000;
+}
+
+.dropdown-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 16px;
+  border: none;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.dropdown-option:hover {
+  background: #2a2d3d;
+}


### PR DESCRIPTION
## Summary
- add CSS variable `--card-bg` for dark cards and apply to CompactReviewCard
- lighten rating text color for readability
- allow every filter in FilterBar to toggle on/off

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f4be27048329a8d8f312e150403f