### PR TITLE
Add PayPal email verification UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ function App() {
 }
 
 export default App;
+
+## Payment Setup
+
+Shop owners can edit the PayPal address used for receiving payments directly on the shop detail page. After entering an address, click **Send Verification Code** to simulate sending an email with a one-time code. Entering the displayed code marks the address as verified and ready to receive funds.

--- a/src/components/ItemDetailPage.js
+++ b/src/components/ItemDetailPage.js
@@ -1,11 +1,15 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { ArrowLeft, Camera, TrendingUp, Clock, MapPin, Heart, MessageCircle, CheckCircle } from "lucide-react";
+import PayPalEmailSettings from "./PayPalEmailSettings";
 import StarRating from "./StarRating";
 // New ItemDetailPage component
 const ItemDetailPage = ({ generateImage, item, onBack, language, categories, citiesData, bangkokStreetsData, generatedImages, setGeneratedImages }) => {
 
- const currentItemImageStatus = generatedImages[item.id];
- const displayName = language === 'th' && item.itemName_th ? item.itemName_th : item.itemName;
+const currentItemImageStatus = generatedImages[item.id];
+const displayName = language === 'th' && item.itemName_th ? item.itemName_th : item.itemName;
+
+ const [paypalEmail, setPaypalEmail] = useState(item.paypalEmail || '');
+ const [paypalVerified, setPaypalVerified] = useState(item.paypalVerified || false);
 
 // kick off image‐generation when this page mounts (or status changes)
 useEffect(() => {
@@ -194,24 +198,31 @@ useEffect(() => {
                         </div>
 
                         <div className="grid grid-cols-2 gap-4 mb-6">
-                            <div className="bg-gradient-to-br from-gray-800/50 to-gray-700/30 backdrop-blur-sm rounded-xl p-4 border border-gray-700/50">
-                                <div className="flex items-center gap-2 text-purple-400 mb-2">
-                                    <TrendingUp size={18} />
-                                    <span className="text-sm font-semibold">{language === 'en' ? "Activity" : "กิจกรรม"}</span>
-                                </div>
-                                <p className="text-lg font-bold text-gray-100">{language === 'en' ? "High" : "สูง"}</p>
-                            </div>
-                            <div className="bg-gradient-to-br from-gray-800/50 to-gray-700/30 backdrop-blur-sm rounded-xl p-4 border border-gray-700/50">
-                                <div className="flex items-center gap-2 text-blue-400 mb-2">
-                                    <Clock size={18} />
-                                    <span className="text-sm font-semibold">{language === 'en' ? "Last Review" : "รีวิวล่าสุด"}</span>
-                                </div>
-                                <p className="text-lg font-bold text-gray-100">{language === 'en' ? "Recent" : "เร็วๆ นี้"}</p>
-                            </div>
-                        </div>
+                            <div className="bg-gradient-to-br from-gray-800/50 to-gray-700/30 backdrop-blur-sm rounded-xl p-4 border border-gray-700/50">
+                                <div className="flex items-center gap-2 text-purple-400 mb-2">
+                                    <TrendingUp size={18} />
+                                    <span className="text-sm font-semibold">{language === 'en' ? "Activity" : "กิจกรรม"}</span>
+                                </div>
+                                <p className="text-lg font-bold text-gray-100">{language === 'en' ? "High" : "สูง"}</p>
+                            </div>
+                            <div className="bg-gradient-to-br from-gray-800/50 to-gray-700/30 backdrop-blur-sm rounded-xl p-4 border border-gray-700/50">
+                                <div className="flex items-center gap-2 text-blue-400 mb-2">
+                                    <Clock size={18} />
+                                    <span className="text-sm font-semibold">{language === 'en' ? "Last Review" : "รีวิวล่าสุด"}</span>
+                                </div>
+                                <p className="text-lg font-bold text-gray-100">{language === 'en' ? "Recent" : "เร็วๆ นี้"}</p>
+                            </div>
+                        </div>
 
-                        <div className="space-y-4">
-                            <h3 className="text-xl font-bold text-gray-100 mb-4">{language === 'en' ? "All Reviews" : "รีวิวทั้งหมด"}</h3>
+                        <PayPalEmailSettings
+                            initialEmail={paypalEmail}
+                            initialVerified={paypalVerified}
+                            onEmailChange={setPaypalEmail}
+                            onVerified={setPaypalVerified}
+                        />
+
+                        <div className="space-y-4">
+                            <h3 className="text-xl font-bold text-gray-100 mb-4">{language === 'en' ? "All Reviews" : "รีวิวทั้งหมด"}</h3>
                             {item.reviews && item.reviews.length > 0 ? (
                                 item.reviews.sort((a, b) => new Date(b.date) - new Date(a.date)).map((review) => (
                                     <div key={review.id} className="bg-gray-800/30 backdrop-blur-sm rounded-xl p-5 border border-gray-700/50 hover:border-gray-600/50 transition-all duration-300">

--- a/src/components/PayPalEmailSettings.jsx
+++ b/src/components/PayPalEmailSettings.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+
+const PayPalEmailSettings = ({ initialEmail = '', initialVerified = false, onEmailChange, onVerified }) => {
+  const [email, setEmail] = useState(initialEmail);
+  const [verified, setVerified] = useState(initialVerified);
+  const [verificationSent, setVerificationSent] = useState(false);
+  const [verificationCode, setVerificationCode] = useState('');
+  const [enteredCode, setEnteredCode] = useState('');
+
+  const handleSendVerification = () => {
+    const code = Math.floor(100000 + Math.random() * 900000).toString();
+    setVerificationCode(code);
+    setVerificationSent(true);
+  };
+
+  const handleVerify = () => {
+    if (enteredCode === verificationCode) {
+      setVerified(true);
+      setVerificationSent(false);
+      setVerificationCode('');
+      if (onVerified) onVerified(true);
+    } else {
+      alert('Verification code does not match');
+    }
+  };
+
+  const handleEmailBlur = () => {
+    if (onEmailChange) {
+      onEmailChange(email);
+    }
+  };
+
+  return (
+    <div className="bg-gray-800/50 backdrop-blur-sm rounded-xl p-4 border border-gray-700/50 space-y-2 mt-6">
+      <h3 className="text-lg font-bold text-gray-100">PayPal Payment Setup</h3>
+      <label className="block text-sm font-medium text-gray-300">PayPal Email</label>
+      <input
+        type="email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        onBlur={handleEmailBlur}
+        className="w-full px-3 py-2 rounded-md bg-gray-700 text-sm focus:outline-none"
+      />
+      {verified ? (
+        <p className="text-green-400 text-sm">Verified</p>
+      ) : (
+        <>
+          <button
+            onClick={handleSendVerification}
+            className="mt-2 bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded"
+          >
+            {verificationSent ? 'Resend Code' : 'Send Verification Code'}
+          </button>
+          {verificationSent && (
+            <div className="mt-2 space-y-1">
+              <p className="text-xs text-gray-400">
+                Verification code sent (simulation). Enter it below:
+              </p>
+              <p className="text-xs text-gray-400">Code: {verificationCode}</p>
+              <input
+                type="text"
+                value={enteredCode}
+                onChange={e => setEnteredCode(e.target.value)}
+                className="w-full px-3 py-2 rounded-md bg-gray-700 text-sm focus:outline-none"
+              />
+              <button
+                onClick={handleVerify}
+                className="mt-1 bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
+              >
+                Verify
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default PayPalEmailSettings;


### PR DESCRIPTION
## Summary
- add `PayPalEmailSettings` component for entering and verifying a PayPal address
- integrate PayPal settings into `ItemDetailPage`
- document the new flow in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854860ae69c8329a8b7553220d25024