### PR TITLE
Add PromptPay QR generator utility and update QR modal

### DIFF
--- a/src/components/PromptPayQRModal.jsx
+++ b/src/components/PromptPayQRModal.jsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import * as promptpay from 'promptpay-qr';
 import QRCode from 'qrcode';
+import { generatePromptPayPayload } from '../utils/promptpay';
 
 export default function PromptPayQRModal({ open, onClose, promptPayId, accountName, amount, onComplete }) {
   const [qrImage, setQrImage] = useState('');
 
   useEffect(() => {
     if (open && promptPayId) {
-      const payload = promptpay.generate(promptPayId, { amount });
+      const payload = generatePromptPayPayload(promptPayId, amount);
       QRCode.toDataURL(payload, { width: 256 }, (err, url) => {
         if (!err) setQrImage(url);
       });

--- a/src/utils/promptpay.js
+++ b/src/utils/promptpay.js
@@ -1,0 +1,13 @@
+// Minimal PromptPay QR payload generator for Thai mobile numbers
+export function generatePromptPayPayload(mobileNumber, amount) {
+  let m = mobileNumber.replace(/[^0-9]/g, '');
+  if (m.length === 10 && m.startsWith('0')) {
+    m = '66' + m.substring(1);
+  }
+  let payload = `00020101021129370016A00000067701011101130066${m.length}${m}`;
+  if (amount) {
+    payload += `53037646304${Number(amount).toFixed(2).replace('.', '')}`;
+  }
+  payload += '6304';
+  return payload;
+}


### PR DESCRIPTION
## Summary
- implement a small PromptPay QR payload generator
- update QR modal to use local PromptPay generator utility

## Testing
- `npm install qrcode` *(fails: 403 Forbidden)*
- `npm test -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a8423a00832994c5da43d876b4f9